### PR TITLE
Remove protocol part of JS libraries

### DIFF
--- a/introToAngular/exampleViewer/index.html
+++ b/introToAngular/exampleViewer/index.html
@@ -11,18 +11,18 @@
     <title>Example Viewer</title>
 
     <!-- Angular web application framework -->
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
 
     <!-- CodeMirror syntax highlighing code editor -->
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/codemirror/3.22.0/codemirror.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/codemirror/3.22.0/mode/htmlmixed/htmlmixed.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/codemirror/3.22.0/mode/xml/xml.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/codemirror/3.22.0/mode/javascript/javascript.min.js"></script> 
+    <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/3.22.0/codemirror.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/3.22.0/mode/htmlmixed/htmlmixed.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/3.22.0/mode/xml/xml.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/3.22.0/mode/javascript/javascript.min.js"></script> 
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/codemirror/3.22.0/codemirror.css">
 
     <!-- Marked markdown parser -->
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/marked/0.3.1/marked.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/marked/0.3.1/marked.min.js"></script>
 
     <!-- Our CSS -->
     <link rel="stylesheet" type="text/css" href="styles.css">


### PR DESCRIPTION
The example viewer breaks on modern browser versions where mixed content is blocked by default (Github pages are served via https). Removing the protocol part of the URL fixes this as CDNJS is also able to serve via https.
