### PR TITLE
Make it work with https everywhere

### DIFF
--- a/introToAngular/exampleViewer/app.js
+++ b/introToAngular/exampleViewer/app.js
@@ -77,8 +77,9 @@ app.controller('ExampleDetailCtrl',
     function ($scope, $routeParams, $http, $sce, examples){
   examples.find($routeParams.exampleNumber, function(example) {
     $scope.example = example;
-    $scope.runUrl = '../examples/snapshots/' + example.name;
-    $http.get($scope.runUrl + '/README.md').success(function(data) {
+    var examplePath = '../examples/snapshots/' + example.name;
+    $scope.runUrl = examplePath + '/index.html';
+    $http.get(examplePath + '/README.md').success(function(data) {
       // Remove first line, as it appears elsewhere on the page (called 'message').
       var md = data.split('\n').splice(1).join('\n');
       $scope.readme = $sce.trustAsHtml(marked(md));

--- a/introToAngular/examples/country_1.json
+++ b/introToAngular/examples/country_1.json
@@ -1,7 +1,7 @@
 {
   "name": "China",
   "population": 1359821000,
-  "flagURL": "http://upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
+  "flagURL": "//upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
   "capital": "Beijing",
   "gdp": 12261
 }

--- a/introToAngular/examples/country_2.json
+++ b/introToAngular/examples/country_2.json
@@ -1,7 +1,7 @@
 {
   "name": "India",
   "population": 1205625000,
-  "flagURL": "http://upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
+  "flagURL": "//upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
   "capital": "New Delhi",
   "gdp": 4716
 }

--- a/introToAngular/examples/country_3.json
+++ b/introToAngular/examples/country_3.json
@@ -1,7 +1,7 @@
 {
   "name": "United States of America",
   "population": 312247000,
-  "flagURL": "http://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
+  "flagURL": "//upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
   "capital": "Washington, D.C.",
   "gdp": 16244
 }

--- a/introToAngular/examples/index.html
+++ b/introToAngular/examples/index.html
@@ -3,8 +3,8 @@
     <meta charset="utf-8">
     <title>Angular.js Example</title>
 
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
 
     <script src="countryControllers.js"></script>
     <script src="countriesFactory.js"></script>

--- a/introToAngular/examples/snapshots/snapshot05/index.html
+++ b/introToAngular/examples/snapshots/snapshot05/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="utf-8">
     <title>DIY One-way Data Binding with jQuery</title>
-    <script src="http://code.jquery.com/jquery-2.0.3.min.js"></script>
+    <script src="//code.jquery.com/jquery-2.0.3.min.js"></script>
   </head>
   <body>
     Name:<input id="textInput" type="text"/>

--- a/introToAngular/examples/snapshots/snapshot06/index.html
+++ b/introToAngular/examples/snapshots/snapshot06/index.html
@@ -2,9 +2,9 @@
   <head>
     <meta charset="utf-8">
     <title>DIY One-way Data Binding with Backbone</title>
-    <script src="http://code.jquery.com/jquery-2.0.3.min.js"></script>
-    <script src="http://jashkenas.github.io/underscore/underscore-min.js"></script>
-    <script src="http://jashkenas.github.io/backbone/backbone-min.js"></script>
+    <script src="//code.jquery.com/jquery-2.0.3.min.js"></script>
+    <script src="//jashkenas.github.io/underscore/underscore-min.js"></script>
+    <script src="//jashkenas.github.io/backbone/backbone-min.js"></script>
   </head>
   <body>
     Name:<input id="textInput" type="text"/>

--- a/introToAngular/examples/snapshots/snapshot07/index.html
+++ b/introToAngular/examples/snapshots/snapshot07/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
   </head>
   <body>
     Name:<input ng-model="name" type="text"/>

--- a/introToAngular/examples/snapshots/snapshot08/index.html
+++ b/introToAngular/examples/snapshots/snapshot08/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
   </head>
   <body>
     Name:<input ng-model="name" type="text"/>

--- a/introToAngular/examples/snapshots/snapshot09/index.html
+++ b/introToAngular/examples/snapshots/snapshot09/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
   </head>
   <body>
     First name:<input ng-model="firstName" type="text"/>

--- a/introToAngular/examples/snapshots/snapshot10/index.html
+++ b/introToAngular/examples/snapshots/snapshot10/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
     <script>
       function NameCtrl($scope){
         $scope.firstName = 'John';

--- a/introToAngular/examples/snapshots/snapshot11/index.html
+++ b/introToAngular/examples/snapshots/snapshot11/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
     <script>
       var nameApp = angular.module('nameApp', []);
       nameApp.controller('NameCtrl', function ($scope){

--- a/introToAngular/examples/snapshots/snapshot12/index.html
+++ b/introToAngular/examples/snapshots/snapshot12/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
     <script>
       var nameApp = angular.module('nameApp', []);
       nameApp.controller('NameCtrl', function ($scope){

--- a/introToAngular/examples/snapshots/snapshot13/index.html
+++ b/introToAngular/examples/snapshots/snapshot13/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
     <script>
       var nameApp = angular.module('nameApp', []);
       nameApp.controller('NameCtrl', function ($scope){

--- a/introToAngular/examples/snapshots/snapshot14/index.html
+++ b/introToAngular/examples/snapshots/snapshot14/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
     <script>
       var nameApp = angular.module('nameApp', []);
       nameApp.controller('NameCtrl', function ($scope){

--- a/introToAngular/examples/snapshots/snapshot15/index.html
+++ b/introToAngular/examples/snapshots/snapshot15/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
     <script>
       var nameApp = angular.module('nameApp', []);
       nameApp.controller('NameCtrl', function ($scope){

--- a/introToAngular/examples/snapshots/snapshot16/index.html
+++ b/introToAngular/examples/snapshots/snapshot16/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
     <script>
       var nameApp = angular.module('nameApp', []);
       nameApp.controller('NameCtrl', function ($scope){

--- a/introToAngular/examples/snapshots/snapshot17/index.html
+++ b/introToAngular/examples/snapshots/snapshot17/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
     <script>
       var nameApp = angular.module('nameApp', []);
       nameApp.controller('NameCtrl', function ($scope){

--- a/introToAngular/examples/snapshots/snapshot18/index.html
+++ b/introToAngular/examples/snapshots/snapshot18/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
     <script>
       var countryApp = angular.module('countryApp', []);
       countryApp.controller('CountryCtrl', function ($scope){

--- a/introToAngular/examples/snapshots/snapshot19/index.html
+++ b/introToAngular/examples/snapshots/snapshot19/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
     <script>
       var countryApp = angular.module('countryApp', []);
       countryApp.controller('CountryCtrl', function ($scope){

--- a/introToAngular/examples/snapshots/snapshot20/index.html
+++ b/introToAngular/examples/snapshots/snapshot20/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
     <script>
       var countryApp = angular.module('countryApp', []);
       countryApp.controller('CountryCtrl', function ($scope, $http){

--- a/introToAngular/examples/snapshots/snapshot21/index.html
+++ b/introToAngular/examples/snapshots/snapshot21/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
     <script>
       var countryApp = angular.module('countryApp', []);
       countryApp.controller('CountryCtrl', ['$scope', '$http', function (scope, http){

--- a/introToAngular/examples/snapshots/snapshot22/index.html
+++ b/introToAngular/examples/snapshots/snapshot22/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
     <script>
       var countryApp = angular.module('countryApp', []);
       countryApp.controller('CountryCtrl', ['$scope', '$http', function (scope, http){

--- a/introToAngular/examples/snapshots/snapshot23/index.html
+++ b/introToAngular/examples/snapshots/snapshot23/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
     <script>
       var countryApp = angular.module('countryApp', []);
       countryApp.controller('CountryCtrl', ['$scope', '$http', function (scope, http){

--- a/introToAngular/examples/snapshots/snapshot24/index.html
+++ b/introToAngular/examples/snapshots/snapshot24/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
     <script>
       var countryApp = angular.module('countryApp', []);
       countryApp.controller('CountryCtrl', ['$scope', '$http', function (scope, http){

--- a/introToAngular/examples/snapshots/snapshot25/index.html
+++ b/introToAngular/examples/snapshots/snapshot25/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
     <script>
       var countryApp = angular.module('countryApp', []);
       countryApp.controller('CountryCtrl', function ($scope, $http){

--- a/introToAngular/examples/snapshots/snapshot26/index.html
+++ b/introToAngular/examples/snapshots/snapshot26/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
     <script>
       var countryApp = angular.module('countryApp', []);
       countryApp.controller('CountryCtrl', function ($scope, $http){

--- a/introToAngular/examples/snapshots/snapshot27/countries.json
+++ b/introToAngular/examples/snapshots/snapshot27/countries.json
@@ -2,16 +2,16 @@
   {
     "name": "China",
     "population": 1359821000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg"
+    "flagURL": "//upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg"
   },
   {
     "name": "India",
     "population": 1205625000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg"
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg"
   },
   {
     "name": "United States of America",
     "population": 312247000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg"
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg"
   }
 ]

--- a/introToAngular/examples/snapshots/snapshot27/index.html
+++ b/introToAngular/examples/snapshots/snapshot27/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
     <script>
       var countryApp = angular.module('countryApp', []);
       countryApp.controller('CountryCtrl', function ($scope, $http){

--- a/introToAngular/examples/snapshots/snapshot28/countries.json
+++ b/introToAngular/examples/snapshots/snapshot28/countries.json
@@ -2,16 +2,16 @@
   {
     "name": "China",
     "population": 1359821000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg"
+    "flagURL": "//upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg"
   },
   {
     "name": "India",
     "population": 1205625000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg"
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg"
   },
   {
     "name": "United States of America",
     "population": 312247000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg"
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg"
   }
 ]

--- a/introToAngular/examples/snapshots/snapshot28/index.html
+++ b/introToAngular/examples/snapshots/snapshot28/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
     <script>
       var countryApp = angular.module('countryApp', []);
       countryApp.controller('CountryCtrl', function ($scope, $http){

--- a/introToAngular/examples/snapshots/snapshot29/countries.json
+++ b/introToAngular/examples/snapshots/snapshot29/countries.json
@@ -2,19 +2,19 @@
   {
     "name": "China",
     "population": 1359821000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
     "capital": "Beijing"
   },
   {
     "name": "India",
     "population": 1205625000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
     "capital": "New Delhi"
   },
   {
     "name": "United States of America",
     "population": 312247000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
     "capital": "Washington, D.C."
   }
 ]

--- a/introToAngular/examples/snapshots/snapshot29/index.html
+++ b/introToAngular/examples/snapshots/snapshot29/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
     <script>
       var countryApp = angular.module('countryApp', []);
       countryApp.controller('CountryCtrl', function ($scope, $http){

--- a/introToAngular/examples/snapshots/snapshot30/countries.json
+++ b/introToAngular/examples/snapshots/snapshot30/countries.json
@@ -2,21 +2,21 @@
   {
     "name": "China",
     "population": 1359821000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
     "capital": "Beijing",
     "gdp": 12261
   },
   {
     "name": "India",
     "population": 1205625000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
     "capital": "New Delhi",
     "gdp": 4716
   },
   {
     "name": "United States of America",
     "population": 312247000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
     "capital": "Washington, D.C.",
     "gdp": 16244
   }

--- a/introToAngular/examples/snapshots/snapshot30/index.html
+++ b/introToAngular/examples/snapshots/snapshot30/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
     <script>
       var countryApp = angular.module('countryApp', []);
       countryApp.controller('CountryCtrl', function ($scope, $http){

--- a/introToAngular/examples/snapshots/snapshot31/countries.json
+++ b/introToAngular/examples/snapshots/snapshot31/countries.json
@@ -2,21 +2,21 @@
   {
     "name": "China",
     "population": 1359821000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
     "capital": "Beijing",
     "gdp": 12261
   },
   {
     "name": "India",
     "population": 1205625000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
     "capital": "New Delhi",
     "gdp": 4716
   },
   {
     "name": "United States of America",
     "population": 312247000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
     "capital": "Washington, D.C.",
     "gdp": 16244
   }

--- a/introToAngular/examples/snapshots/snapshot31/index.html
+++ b/introToAngular/examples/snapshots/snapshot31/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
     <script>
       var countryApp = angular.module('countryApp', []);
       countryApp.controller('CountryCtrl', function ($scope, $http){

--- a/introToAngular/examples/snapshots/snapshot32/countries.json
+++ b/introToAngular/examples/snapshots/snapshot32/countries.json
@@ -2,21 +2,21 @@
   {
     "name": "China",
     "population": 1359821000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
     "capital": "Beijing",
     "gdp": 12261
   },
   {
     "name": "India",
     "population": 1205625000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
     "capital": "New Delhi",
     "gdp": 4716
   },
   {
     "name": "United States of America",
     "population": 312247000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
     "capital": "Washington, D.C.",
     "gdp": 16244
   }

--- a/introToAngular/examples/snapshots/snapshot32/index.html
+++ b/introToAngular/examples/snapshots/snapshot32/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
     <script>
       var countryApp = angular.module('countryApp', []);
       countryApp.controller('CountryCtrl', function ($scope, $http){

--- a/introToAngular/examples/snapshots/snapshot33/countries.json
+++ b/introToAngular/examples/snapshots/snapshot33/countries.json
@@ -2,21 +2,21 @@
   {
     "name": "China",
     "population": 1359821000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
     "capital": "Beijing",
     "gdp": 12261
   },
   {
     "name": "India",
     "population": 1205625000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
     "capital": "New Delhi",
     "gdp": 4716
   },
   {
     "name": "United States of America",
     "population": 312247000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
     "capital": "Washington, D.C.",
     "gdp": 16244
   }

--- a/introToAngular/examples/snapshots/snapshot33/index.html
+++ b/introToAngular/examples/snapshots/snapshot33/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js"></script>
     <script>
       var countryApp = angular.module('countryApp', []);
       countryApp.controller('CountryListCtrl', function ($scope, $http){

--- a/introToAngular/examples/snapshots/snapshot34/countries.json
+++ b/introToAngular/examples/snapshots/snapshot34/countries.json
@@ -2,21 +2,21 @@
   {
     "name": "China",
     "population": 1359821000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
     "capital": "Beijing",
     "gdp": 12261
   },
   {
     "name": "India",
     "population": 1205625000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
     "capital": "New Delhi",
     "gdp": 4716
   },
   {
     "name": "United States of America",
     "population": 312247000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
     "capital": "Washington, D.C.",
     "gdp": 16244
   }

--- a/introToAngular/examples/snapshots/snapshot34/index.html
+++ b/introToAngular/examples/snapshots/snapshot34/index.html
@@ -2,8 +2,8 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
     <script>
       var countryApp = angular.module('countryApp', ['ngRoute']);
 

--- a/introToAngular/examples/snapshots/snapshot35/countries.json
+++ b/introToAngular/examples/snapshots/snapshot35/countries.json
@@ -2,21 +2,21 @@
   {
     "name": "China",
     "population": 1359821000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
     "capital": "Beijing",
     "gdp": 12261
   },
   {
     "name": "India",
     "population": 1205625000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
     "capital": "New Delhi",
     "gdp": 4716
   },
   {
     "name": "United States of America",
     "population": 312247000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
     "capital": "Washington, D.C.",
     "gdp": 16244
   }

--- a/introToAngular/examples/snapshots/snapshot35/index.html
+++ b/introToAngular/examples/snapshots/snapshot35/index.html
@@ -2,8 +2,8 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
     <script>
       var countryApp = angular.module('countryApp', ['ngRoute']);
 

--- a/introToAngular/examples/snapshots/snapshot36/countries.json
+++ b/introToAngular/examples/snapshots/snapshot36/countries.json
@@ -2,21 +2,21 @@
   {
     "name": "China",
     "population": 1359821000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
     "capital": "Beijing",
     "gdp": 12261
   },
   {
     "name": "India",
     "population": 1205625000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
     "capital": "New Delhi",
     "gdp": 4716
   },
   {
     "name": "United States of America",
     "population": 312247000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
     "capital": "Washington, D.C.",
     "gdp": 16244
   }

--- a/introToAngular/examples/snapshots/snapshot36/index.html
+++ b/introToAngular/examples/snapshots/snapshot36/index.html
@@ -2,8 +2,8 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
     <script>
       var countryApp = angular.module('countryApp', ['ngRoute']);
 

--- a/introToAngular/examples/snapshots/snapshot37/countries.json
+++ b/introToAngular/examples/snapshots/snapshot37/countries.json
@@ -2,21 +2,21 @@
   {
     "name": "China",
     "population": 1359821000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
     "capital": "Beijing",
     "gdp": 12261
   },
   {
     "name": "India",
     "population": 1205625000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
     "capital": "New Delhi",
     "gdp": 4716
   },
   {
     "name": "United States of America",
     "population": 312247000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
     "capital": "Washington, D.C.",
     "gdp": 16244
   }

--- a/introToAngular/examples/snapshots/snapshot37/index.html
+++ b/introToAngular/examples/snapshots/snapshot37/index.html
@@ -2,8 +2,8 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
     <script>
       var countryApp = angular.module('countryApp', ['ngRoute']);
 

--- a/introToAngular/examples/snapshots/snapshot38/countries.json
+++ b/introToAngular/examples/snapshots/snapshot38/countries.json
@@ -2,21 +2,21 @@
   {
     "name": "China",
     "population": 1359821000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
     "capital": "Beijing",
     "gdp": 12261
   },
   {
     "name": "India",
     "population": 1205625000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
     "capital": "New Delhi",
     "gdp": 4716
   },
   {
     "name": "United States of America",
     "population": 312247000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
     "capital": "Washington, D.C.",
     "gdp": 16244
   }

--- a/introToAngular/examples/snapshots/snapshot38/index.html
+++ b/introToAngular/examples/snapshots/snapshot38/index.html
@@ -2,8 +2,8 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
     <script>
       var countryApp = angular.module('countryApp', ['ngRoute']);
 

--- a/introToAngular/examples/snapshots/snapshot39/countries.json
+++ b/introToAngular/examples/snapshots/snapshot39/countries.json
@@ -2,21 +2,21 @@
   {
     "name": "China",
     "population": 1359821000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
     "capital": "Beijing",
     "gdp": 12261
   },
   {
     "name": "India",
     "population": 1205625000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
     "capital": "New Delhi",
     "gdp": 4716
   },
   {
     "name": "United States of America",
     "population": 312247000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
     "capital": "Washington, D.C.",
     "gdp": 16244
   }

--- a/introToAngular/examples/snapshots/snapshot39/index.html
+++ b/introToAngular/examples/snapshots/snapshot39/index.html
@@ -2,8 +2,8 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
     <script>
       var countryApp = angular.module('countryApp', ['ngRoute']);
 

--- a/introToAngular/examples/snapshots/snapshot40/countries.json
+++ b/introToAngular/examples/snapshots/snapshot40/countries.json
@@ -2,21 +2,21 @@
   {
     "name": "China",
     "population": 1359821000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
     "capital": "Beijing",
     "gdp": 12261
   },
   {
     "name": "India",
     "population": 1205625000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
     "capital": "New Delhi",
     "gdp": 4716
   },
   {
     "name": "United States of America",
     "population": 312247000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
     "capital": "Washington, D.C.",
     "gdp": 16244
   }

--- a/introToAngular/examples/snapshots/snapshot40/index.html
+++ b/introToAngular/examples/snapshots/snapshot40/index.html
@@ -2,8 +2,8 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
     <script>
       var countryApp = angular.module('countryApp', ['ngRoute']);
 

--- a/introToAngular/examples/snapshots/snapshot41/countries.json
+++ b/introToAngular/examples/snapshots/snapshot41/countries.json
@@ -2,21 +2,21 @@
   {
     "name": "China",
     "population": 1359821000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
     "capital": "Beijing",
     "gdp": 12261
   },
   {
     "name": "India",
     "population": 1205625000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
     "capital": "New Delhi",
     "gdp": 4716
   },
   {
     "name": "United States of America",
     "population": 312247000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
     "capital": "Washington, D.C.",
     "gdp": 16244
   }

--- a/introToAngular/examples/snapshots/snapshot41/index.html
+++ b/introToAngular/examples/snapshots/snapshot41/index.html
@@ -2,8 +2,8 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
     <script>
       var countryApp = angular.module('countryApp', ['ngRoute']);
 

--- a/introToAngular/examples/snapshots/snapshot42/countries.json
+++ b/introToAngular/examples/snapshots/snapshot42/countries.json
@@ -2,21 +2,21 @@
   {
     "name": "China",
     "population": 1359821000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
     "capital": "Beijing",
     "gdp": 12261
   },
   {
     "name": "India",
     "population": 1205625000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
     "capital": "New Delhi",
     "gdp": 4716
   },
   {
     "name": "United States of America",
     "population": 312247000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
     "capital": "Washington, D.C.",
     "gdp": 16244
   }

--- a/introToAngular/examples/snapshots/snapshot42/index.html
+++ b/introToAngular/examples/snapshots/snapshot42/index.html
@@ -2,8 +2,8 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
     <script>
       var countryApp = angular.module('countryApp', ['ngRoute']);
 

--- a/introToAngular/examples/snapshots/snapshot43/countries.json
+++ b/introToAngular/examples/snapshots/snapshot43/countries.json
@@ -2,21 +2,21 @@
   {
     "name": "China",
     "population": 1359821000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
     "capital": "Beijing",
     "gdp": 12261
   },
   {
     "name": "India",
     "population": 1205625000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
     "capital": "New Delhi",
     "gdp": 4716
   },
   {
     "name": "United States of America",
     "population": 312247000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
     "capital": "Washington, D.C.",
     "gdp": 16244
   }

--- a/introToAngular/examples/snapshots/snapshot43/index.html
+++ b/introToAngular/examples/snapshots/snapshot43/index.html
@@ -2,8 +2,8 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
     <script>
       var countryApp = angular.module('countryApp', ['ngRoute']);
 

--- a/introToAngular/examples/snapshots/snapshot44/countries.json
+++ b/introToAngular/examples/snapshots/snapshot44/countries.json
@@ -2,21 +2,21 @@
   {
     "name": "China",
     "population": 1359821000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
     "capital": "Beijing",
     "gdp": 12261
   },
   {
     "name": "India",
     "population": 1205625000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
     "capital": "New Delhi",
     "gdp": 4716
   },
   {
     "name": "United States of America",
     "population": 312247000,
-    "flagURL": "http://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
+    "flagURL": "//upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
     "capital": "Washington, D.C.",
     "gdp": 16244
   }

--- a/introToAngular/examples/snapshots/snapshot44/index.html
+++ b/introToAngular/examples/snapshots/snapshot44/index.html
@@ -2,8 +2,8 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
     <script>
       var countryApp = angular.module('countryApp', ['ngRoute']);
 

--- a/introToAngular/examples/snapshots/snapshot45/country_1.json
+++ b/introToAngular/examples/snapshots/snapshot45/country_1.json
@@ -1,7 +1,7 @@
 {
   "name": "China",
   "population": 1359821000,
-  "flagURL": "http://upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
+  "flagURL": "//upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
   "capital": "Beijing",
   "gdp": 12261
 }

--- a/introToAngular/examples/snapshots/snapshot45/country_2.json
+++ b/introToAngular/examples/snapshots/snapshot45/country_2.json
@@ -1,7 +1,7 @@
 {
   "name": "India",
   "population": 1205625000,
-  "flagURL": "http://upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
+  "flagURL": "//upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
   "capital": "New Delhi",
   "gdp": 4716
 }

--- a/introToAngular/examples/snapshots/snapshot45/country_3.json
+++ b/introToAngular/examples/snapshots/snapshot45/country_3.json
@@ -1,7 +1,7 @@
 {
   "name": "United States of America",
   "population": 312247000,
-  "flagURL": "http://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
+  "flagURL": "//upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
   "capital": "Washington, D.C.",
   "gdp": 16244
 }

--- a/introToAngular/examples/snapshots/snapshot45/index.html
+++ b/introToAngular/examples/snapshots/snapshot45/index.html
@@ -2,8 +2,8 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
     <script>
       var countryApp = angular.module('countryApp', ['ngRoute']);
 

--- a/introToAngular/examples/snapshots/snapshot46/country_1.json
+++ b/introToAngular/examples/snapshots/snapshot46/country_1.json
@@ -1,7 +1,7 @@
 {
   "name": "China",
   "population": 1359821000,
-  "flagURL": "http://upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
+  "flagURL": "//upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
   "capital": "Beijing",
   "gdp": 12261
 }

--- a/introToAngular/examples/snapshots/snapshot46/country_2.json
+++ b/introToAngular/examples/snapshots/snapshot46/country_2.json
@@ -1,7 +1,7 @@
 {
   "name": "India",
   "population": 1205625000,
-  "flagURL": "http://upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
+  "flagURL": "//upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
   "capital": "New Delhi",
   "gdp": 4716
 }

--- a/introToAngular/examples/snapshots/snapshot46/country_3.json
+++ b/introToAngular/examples/snapshots/snapshot46/country_3.json
@@ -1,7 +1,7 @@
 {
   "name": "United States of America",
   "population": 312247000,
-  "flagURL": "http://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
+  "flagURL": "//upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
   "capital": "Washington, D.C.",
   "gdp": 16244
 }

--- a/introToAngular/examples/snapshots/snapshot46/index.html
+++ b/introToAngular/examples/snapshots/snapshot46/index.html
@@ -2,8 +2,8 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
     <script>
       var countryApp = angular.module('countryApp', ['ngRoute']);
 

--- a/introToAngular/examples/snapshots/snapshot47/country_1.json
+++ b/introToAngular/examples/snapshots/snapshot47/country_1.json
@@ -1,7 +1,7 @@
 {
   "name": "China",
   "population": 1359821000,
-  "flagURL": "http://upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
+  "flagURL": "//upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
   "capital": "Beijing",
   "gdp": 12261
 }

--- a/introToAngular/examples/snapshots/snapshot47/country_2.json
+++ b/introToAngular/examples/snapshots/snapshot47/country_2.json
@@ -1,7 +1,7 @@
 {
   "name": "India",
   "population": 1205625000,
-  "flagURL": "http://upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
+  "flagURL": "//upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
   "capital": "New Delhi",
   "gdp": 4716
 }

--- a/introToAngular/examples/snapshots/snapshot47/country_3.json
+++ b/introToAngular/examples/snapshots/snapshot47/country_3.json
@@ -1,7 +1,7 @@
 {
   "name": "United States of America",
   "population": 312247000,
-  "flagURL": "http://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
+  "flagURL": "//upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
   "capital": "Washington, D.C.",
   "gdp": 16244
 }

--- a/introToAngular/examples/snapshots/snapshot47/index.html
+++ b/introToAngular/examples/snapshots/snapshot47/index.html
@@ -2,8 +2,8 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
     <script>
       var countryApp = angular.module('countryApp', ['ngRoute']);
 

--- a/introToAngular/examples/snapshots/snapshot48/country_1.json
+++ b/introToAngular/examples/snapshots/snapshot48/country_1.json
@@ -1,7 +1,7 @@
 {
   "name": "China",
   "population": 1359821000,
-  "flagURL": "http://upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
+  "flagURL": "//upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
   "capital": "Beijing",
   "gdp": 12261
 }

--- a/introToAngular/examples/snapshots/snapshot48/country_2.json
+++ b/introToAngular/examples/snapshots/snapshot48/country_2.json
@@ -1,7 +1,7 @@
 {
   "name": "India",
   "population": 1205625000,
-  "flagURL": "http://upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
+  "flagURL": "//upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
   "capital": "New Delhi",
   "gdp": 4716
 }

--- a/introToAngular/examples/snapshots/snapshot48/country_3.json
+++ b/introToAngular/examples/snapshots/snapshot48/country_3.json
@@ -1,7 +1,7 @@
 {
   "name": "United States of America",
   "population": 312247000,
-  "flagURL": "http://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
+  "flagURL": "//upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
   "capital": "Washington, D.C.",
   "gdp": 16244
 }

--- a/introToAngular/examples/snapshots/snapshot48/index.html
+++ b/introToAngular/examples/snapshots/snapshot48/index.html
@@ -2,8 +2,8 @@
   <head>
     <meta charset="utf-8">
     <title>Angular.js Example</title>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
     <script>
       var countryApp = angular.module('countryApp', ['ngRoute']);
 

--- a/introToAngular/examples/snapshots/snapshot49/country_1.json
+++ b/introToAngular/examples/snapshots/snapshot49/country_1.json
@@ -1,7 +1,7 @@
 {
   "name": "China",
   "population": 1359821000,
-  "flagURL": "http://upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
+  "flagURL": "//upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
   "capital": "Beijing",
   "gdp": 12261
 }

--- a/introToAngular/examples/snapshots/snapshot49/country_2.json
+++ b/introToAngular/examples/snapshots/snapshot49/country_2.json
@@ -1,7 +1,7 @@
 {
   "name": "India",
   "population": 1205625000,
-  "flagURL": "http://upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
+  "flagURL": "//upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
   "capital": "New Delhi",
   "gdp": 4716
 }

--- a/introToAngular/examples/snapshots/snapshot49/country_3.json
+++ b/introToAngular/examples/snapshots/snapshot49/country_3.json
@@ -1,7 +1,7 @@
 {
   "name": "United States of America",
   "population": 312247000,
-  "flagURL": "http://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
+  "flagURL": "//upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
   "capital": "Washington, D.C.",
   "gdp": 16244
 }

--- a/introToAngular/examples/snapshots/snapshot49/index.html
+++ b/introToAngular/examples/snapshots/snapshot49/index.html
@@ -3,8 +3,8 @@
     <meta charset="utf-8">
     <title>Angular.js Example</title>
 
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
 
     <script src="countryControllers.js"></script>
     <script src="app.js"></script>

--- a/introToAngular/examples/snapshots/snapshot50/country_1.json
+++ b/introToAngular/examples/snapshots/snapshot50/country_1.json
@@ -1,7 +1,7 @@
 {
   "name": "China",
   "population": 1359821000,
-  "flagURL": "http://upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
+  "flagURL": "//upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg",
   "capital": "Beijing",
   "gdp": 12261
 }

--- a/introToAngular/examples/snapshots/snapshot50/country_2.json
+++ b/introToAngular/examples/snapshots/snapshot50/country_2.json
@@ -1,7 +1,7 @@
 {
   "name": "India",
   "population": 1205625000,
-  "flagURL": "http://upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
+  "flagURL": "//upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
   "capital": "New Delhi",
   "gdp": 4716
 }

--- a/introToAngular/examples/snapshots/snapshot50/country_3.json
+++ b/introToAngular/examples/snapshots/snapshot50/country_3.json
@@ -1,7 +1,7 @@
 {
   "name": "United States of America",
   "population": 312247000,
-  "flagURL": "http://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
+  "flagURL": "//upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
   "capital": "Washington, D.C.",
   "gdp": 16244
 }

--- a/introToAngular/examples/snapshots/snapshot50/index.html
+++ b/introToAngular/examples/snapshots/snapshot50/index.html
@@ -3,8 +3,8 @@
     <meta charset="utf-8">
     <title>Angular.js Example</title>
 
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular-route.min.js"></script>
 
     <script src="countryControllers.js"></script>
     <script src="countriesFactory.js"></script>


### PR DESCRIPTION
Sorry for bothering you again; it looks like I ~~spoke~~ sent a pull request too soon.

I tried to use the examples with [HTTPS Everywhere](https://www.eff.org/https-everywhere) enabled and they still didn't work due to mixed content being blocked. So now I fixed (and tested) all of them to make sure they work over https as well as over http.

The only code change is that the `iframe` now always points to the `index.html` file of the snapshot instead of just the folder. This is because Github redirects folders from https to http. All other changes are just removing the http protocol prefix.

Notice I did touch neither the `example.json` nor the `compileReadme.js` which seems to be generating it, simply because the `runUrl` property of the JSON objects is never used.

Oh, and thank you again for this awesome tutorial!
