### PR TITLE
Adding a missing 'c' in kitchen

### DIFF
--- a/introToAngular/README.md
+++ b/introToAngular/README.md
@@ -111,11 +111,11 @@ The following libraries lay the foundation for many data binding frameworks:
 
 It is straightforward to teach yourself about Angular, as there are so many learning resources on the Web.
 
-### Birds-eye-view:
+### Bird's-eye-view:
 
  * [Learn Angularjs This Weekend](http://joelhooks.com/blog/2013/08/03/learn-angularjs-in-a-weekend/) - Advice on which resources to use for getting up to speed on Angular.
  * [A Better Way to Learn AngularJS](http://www.thinkster.io/angularjs/GtaQ0oMGIl/a-better-way-to-learn-angularjs) - A great collection of links to resources for learning Angular.
- * [AngularJS-Learning](https://github.com/jmcunningham/AngularJS-Learning) - A kithen sink of links to Angular learning resources.
+ * [AngularJS-Learning](https://github.com/jmcunningham/AngularJS-Learning) - A kitchen sink of links to Angular learning resources.
 
 ### Introductory tutorials and guides:
 


### PR DESCRIPTION
Just a small grammatical error under the section "Bird's eye view".
